### PR TITLE
fix: handling error code when passing bad arguments to path variables

### DIFF
--- a/kub-super-admin-backend/src/main/java/education/kub/superadmin/controller/handler/GlobalExceptionHandler.java
+++ b/kub-super-admin-backend/src/main/java/education/kub/superadmin/controller/handler/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.server.ResponseStatusException;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
@@ -51,6 +52,12 @@ public class GlobalExceptionHandler extends BaseExceptionHandling {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Problem> handleValidationExceptions(MethodArgumentNotValidException ex, HttpServletRequest request) {
         final Problem problem = buildProblem(request.getRequestURI(), Status.UNPROCESSABLE_ENTITY, ex);
+        return ResponseEntity.status(Objects.requireNonNull(problem.getStatus()).getStatusCode()).body(problem);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Problem> handleValidationExceptions(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+        final Problem problem = buildProblem(request.getRequestURI(), Status.BAD_REQUEST, ex);
         return ResponseEntity.status(Objects.requireNonNull(problem.getStatus()).getStatusCode()).body(problem);
     }
 }


### PR DESCRIPTION
Added new exception handler to return Bad Request (404) when string is passed as path variable but value has to be numerical instead.