### PR TITLE
Fix: BACK-24 Admin DTOs regex. Allowed UA letters, hyphen, apostrophe

### DIFF
--- a/kub-super-admin-backend/src/main/java/education/kub/superadmin/dto/AdminRequestDTO.java
+++ b/kub-super-admin-backend/src/main/java/education/kub/superadmin/dto/AdminRequestDTO.java
@@ -14,20 +14,26 @@ import lombok.Setter;
 @Setter
 public class AdminRequestDTO {
     @JsonProperty("last_name")
-    @NotBlank(message = "lastName can't be blank")
-    @Size(min = 1, max = 32, message = "lastName must have length in interval [1,32]")
-    @Pattern(regexp = "^[a-zA-Zа-яА-Я]+$", message = "lastName must contain only Latin or Cyrillic letters")
+    @NotBlank(message = "last_name can't be blank")
+    @Size(min = 1, max = 32, message = "last_name must have length in interval [1,32]")
+    @Pattern(regexp = "^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+            "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
+            message = "last_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
     private String lastName;
 
     @JsonProperty("first_name")
-    @NotBlank(message = "firstName can't be blank")
-    @Size(min = 1, max = 32, message = "firstName must have length in interval [1,32]")
-    @Pattern(regexp = "^[a-zA-Zа-яА-Я]+$", message = "firstName must contain only Latin or Cyrillic letters")
+    @NotBlank(message = "first_name can't be blank")
+    @Size(min = 1, max = 32, message = "first_name must have length in interval [1,32]")
+    @Pattern(regexp = "^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+            "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
+            message = "first_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
     private String firstName;
 
     @JsonProperty("middle_name")
-    @Size(min = 1, max = 32, message = "middleName must have length in interval [1,32]")
-    @Pattern(regexp = "^[a-zA-Zа-яА-Я]+$", message = "middleName must contain only Latin or Cyrillic letters")
+    @Size(min = 1, max = 32, message = "middle_name must have length in interval [1,32]")
+    @Pattern(regexp = "^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+            "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
+            message = "middle_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
     private String middleName;
 
     @JsonProperty("email")

--- a/kub-super-admin-backend/src/main/java/education/kub/superadmin/dto/AdminUpdateRequestDTO.java
+++ b/kub-super-admin-backend/src/main/java/education/kub/superadmin/dto/AdminUpdateRequestDTO.java
@@ -14,18 +14,24 @@ import lombok.Setter;
 @Setter
 public class AdminUpdateRequestDTO {
     @JsonProperty("last_name")
-    @Size(min = 1, max = 32, message = "lastName must have length in interval [1,32]")
-    @Pattern(regexp = "^[a-zA-Zа-яА-Я]+$", message = "lastName must contain only Latin or Cyrillic letters")
+    @Size(min = 1, max = 32, message = "last_name must have length in interval [1,32]")
+    @Pattern(regexp = "^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+            "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
+            message = "last_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
     private String lastName;
 
     @JsonProperty("first_name")
-    @Size(min = 1, max = 32, message = "firstName must have length in interval [1,32]")
-    @Pattern(regexp = "^[a-zA-Zа-яА-Я]+$", message = "firstName must contain only Latin or Cyrillic letters")
+    @Size(min = 1, max = 32, message = "first_name must have length in interval [1,32]")
+    @Pattern(regexp = "^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+            "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
+            message = "first_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
     private String firstName;
 
     @JsonProperty("middle_name")
-    @Size(max = 32, message = "middleName must have length less than or equal to 32")
-    @Pattern(regexp = "^$|^[a-zA-Zа-яА-Я]+$", message = "middleName must contain only Latin or Cyrillic letters")
+    @Size(max = 32, message = "middle_name must have length less than or equal to 32")
+    @Pattern(regexp = "^$|^(?=.{0,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+            "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
+            message = "middle_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
     private String middleName;
 
     @JsonProperty("email")


### PR DESCRIPTION
according to docs: https://kub-education.github.io/KUB-Documentation-Space/chapters/api-documentation/kub-super-admin-api/admins-management/api/