### PR TITLE
Fix: when middle_name is empty string, returning 400 code when request hasn't json body

### DIFF
--- a/kub-super-admin-backend/src/main/java/education/kub/superadmin/controller/handler/GlobalExceptionHandler.java
+++ b/kub-super-admin-backend/src/main/java/education/kub/superadmin/controller/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -44,6 +45,13 @@ public class GlobalExceptionHandler extends BaseExceptionHandling {
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<Problem> handleException(HttpClientErrorException ex, HttpServletRequest request) {
         final Problem problem = buildProblem(request.getRequestURI(), Status.valueOf(ex.getStatusCode().value()), ex);
+        return ResponseEntity.status(Objects.requireNonNull(problem.getStatus()).getStatusCode()).body(problem);
+    }
+
+    // handles empty request body (https://stackoverflow.com/a/69411467)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Problem> handleException(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        final Problem problem = buildProblem(request.getRequestURI(), Status.valueOf(400), ex);
         return ResponseEntity.status(Objects.requireNonNull(problem.getStatus()).getStatusCode()).body(problem);
     }
 

--- a/kub-super-admin-backend/src/main/java/education/kub/superadmin/dto/AdminRequestDTO.java
+++ b/kub-super-admin-backend/src/main/java/education/kub/superadmin/dto/AdminRequestDTO.java
@@ -17,8 +17,8 @@ public record AdminRequestDTO(
                 message = "first_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
         String firstName,
 
-        @Size(min = 1, max = 32, message = "middle_name must have length in interval [1,32]")
-        @Pattern(regexp = "^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
+        @Size(max = 32, message = "middle_name must have length less than or equal to 32")
+        @Pattern(regexp = "^$|^(?=.{1,32}$)[A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]" +
                 "+(?:[-'ʼ][A-Za-zАБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя]+)*$",
                 message = "middle_name must contain only Latin or Cyrillic letters, hyphen, apostrophe")
         String middleName,

--- a/kub-super-admin-backend/src/main/java/education/kub/superadmin/services/impl/UserServiceImpl.java
+++ b/kub-super-admin-backend/src/main/java/education/kub/superadmin/services/impl/UserServiceImpl.java
@@ -62,6 +62,11 @@ public class UserServiceImpl implements UserService {
                 null,
                 null
         );
+        if (dto.middleName() != null &&
+                dto.middleName().isEmpty()) {
+            user.setMiddleName(null);
+        }
+
         userRepo.save(user);
 
         // check SMTP connection


### PR DESCRIPTION
Fix:
- in user creation, set `middleName` to `null` when `middle_name` in DTO is empty string
- return 400 code instead of 500 when request hasn't json body